### PR TITLE
Make it possible to exclude keys from HashOnlyScraper

### DIFF
--- a/dc_base_scrapers/common.py
+++ b/dc_base_scrapers/common.py
@@ -51,11 +51,12 @@ def dump_table_to_json(table_name, key):
         sort_keys=True, indent=4)
 
 
-def format_json(json_str):
-    return json.dumps(
-        json.loads(json_str, object_pairs_hook=OrderedDict),
-        sort_keys=True, indent=4
-    )
+def format_json(json_str, exclude_keys=None):
+    data = json.loads(json_str, object_pairs_hook=OrderedDict)
+    if isinstance(data, dict) and exclude_keys:
+        for key in exclude_keys:
+            data.pop(key, None)
+    return json.dumps(data, sort_keys=True, indent=4 )
 
 
 def sync_file_to_github(council_id, file_name, content):

--- a/dc_base_scrapers/hashonly_scraper.py
+++ b/dc_base_scrapers/hashonly_scraper.py
@@ -1,3 +1,5 @@
+import json
+
 from dc_base_scrapers.common import (
     BaseScraper,
     format_json,
@@ -21,7 +23,7 @@ class HashOnlyScraper(BaseScraper):
     def make_geometry(self, feature):  # pragma: no cover
         return json.dumps(feature)
 
-    def scrape(self):
+    def scrape(self, exclude_keys=[]):
         data = self.get_data()
 
         if self.extension:
@@ -31,7 +33,7 @@ class HashOnlyScraper(BaseScraper):
                 sync_file_to_github(
                     self.council_id,
                     filename,
-                    format_json(data.decode('utf-8'))
+                    format_json(data.decode('utf-8'), exclude_keys=exclude_keys)
                 )
             else:
                 sync_file_to_github(self.council_id, filename, data)


### PR DESCRIPTION
This is makes it possible to exclude the 'meta' key from the arcgis api
which changes based on return time and other properties, creating a lot
of noise.